### PR TITLE
Update sddm.conf with EnableHiDPI=False (2nd)

### DIFF
--- a/sddm.conf
+++ b/sddm.conf
@@ -11,10 +11,6 @@ User=
 [General]
 # Halt command
 HaltCommand=/bin/systemctl poweroff
-# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
-# but should be false, because its better to make it false to enable it later, by the way
-# it shuld be under General to setting by all XServers.
-EnableHiDPI=False
 
 # Initial NumLock state
 # Valid values: on|off|none
@@ -102,6 +98,10 @@ SessionLogFile=.local/share/sddm/xorg-session.log
 # Path to the Xauthority file, relative to the home directory.
 UserAuthFile=.Xauthority
 
+# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
+# but should be false, because its better to make it false to enable it later
+EnableHiDPI=False
+
 
 [Wayland]
 # Path of the directory containing session files
@@ -113,4 +113,7 @@ SessionCommand=/usr/share/sddm/scripts/wayland-session
 # Path to the user session log file, relative to the home directory.
 SessionLogFile=.local/share/sddm/wayland-session.log
 
+# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
+# but should be false, because its better to make it false to enable it later
+EnableHiDPI=False
 

--- a/sddm.conf
+++ b/sddm.conf
@@ -11,6 +11,10 @@ User=
 [General]
 # Halt command
 HaltCommand=/bin/systemctl poweroff
+# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
+# but should be false, because its better to make it false to enable it later, by the way
+# it shuld be under General to setting by all XServers.
+EnableHiDPI=False
 
 # Initial NumLock state
 # Valid values: on|off|none
@@ -98,8 +102,6 @@ SessionLogFile=.local/share/sddm/xorg-session.log
 # Path to the Xauthority file, relative to the home directory.
 UserAuthFile=.Xauthority
 
-# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
-EnableHiDPI=true
 
 [Wayland]
 # Path of the directory containing session files
@@ -111,5 +113,4 @@ SessionCommand=/usr/share/sddm/scripts/wayland-session
 # Path to the user session log file, relative to the home directory.
 SessionLogFile=.local/share/sddm/wayland-session.log
 
-# Enables Qt's automatic HiDPI scaling. Can be either "true" or "false".Default value is "false".
-EnableHiDPI=true
+


### PR DESCRIPTION
and again..
It should not automatic use HIDPI because over HDMI it is by different TV's automatical
to use HIDPI because this is this configuration's possibility and this HIDPI extension
by UHD ( so Ultra High Device) it is very meaningful / useful
but not under normal HDTV or other 1920x1080 it is not useful because the 
whole it is in to the 2 input/textfilds to tall over the whole Monitor.

and would be nice if become a feedback if change, disable stop or remove this patch.. 
please change it in the config of github.. if this possible ..

best regards
Blacky